### PR TITLE
Destroy semaphore after join

### DIFF
--- a/src/LinearMath/TaskScheduler/btThreadSupportPosix.cpp
+++ b/src/LinearMath/TaskScheduler/btThreadSupportPosix.cpp
@@ -304,8 +304,8 @@ void btThreadSupportPosix::stopThreads()
 		checkPThreadFunction(sem_post(threadStatus.startSemaphore));
 		checkPThreadFunction(sem_wait(m_mainSemaphore));
 
-		destroySem(threadStatus.startSemaphore);
 		checkPThreadFunction(pthread_join(threadStatus.thread, 0));
+		destroySem(threadStatus.startSemaphore);
 	}
 	destroySem(m_mainSemaphore);
 	m_activeThreadStatus.clear();


### PR DESCRIPTION
I get a consistent hang on the pthread worker threads when using btCreateDefaultTaskScheduler() (both my worker threads get stuck on sem_wait() - Line 181) when the semaphore is destroyed before the thread is joined, and the application never exits.

This change resolves this issue in my testing, thought it's difficult to initially see why, however given that both threads end up waiting on a semaphore which has been destroyed the change enforces that that situation cannot happen.